### PR TITLE
Fix/SSCS-10629: Joint party mappings

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/helper/mapping/HearingsMapping.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/helper/mapping/HearingsMapping.java
@@ -62,6 +62,7 @@ public final class HearingsMapping {
         int maxId = getMaxId(caseData.getOtherParties(), appellant, appeal.getRep());
 
         maxId = updatePartyIds(appellant, appeal.getRep(), maxId);
+        maxId = updatePartyIds(caseData.getJointParty(), null, maxId);
         updateOtherPartiesIds(caseData.getOtherParties(), maxId);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/helper/mapping/HearingsMappingTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/helper/mapping/HearingsMappingTest.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.Entity;
 import uk.gov.hmcts.reform.sscs.ccd.domain.HearingOptions;
 import uk.gov.hmcts.reform.sscs.ccd.domain.HearingSubtype;
 import uk.gov.hmcts.reform.sscs.ccd.domain.Issue;
+import uk.gov.hmcts.reform.sscs.ccd.domain.JointParty;
 import uk.gov.hmcts.reform.sscs.ccd.domain.Name;
 import uk.gov.hmcts.reform.sscs.ccd.domain.OtherParty;
 import uk.gov.hmcts.reform.sscs.ccd.domain.Party;
@@ -60,10 +61,10 @@ class HearingsMappingTest extends HearingsMappingBase {
     void buildHearingPayload() throws InvalidMappingException {
         given(hearingDurations.getHearingDuration(BENEFIT_CODE,ISSUE_CODE))
                 .willReturn(new HearingDuration(BenefitCode.PIP_NEW_CLAIM, Issue.DD,
-                        60,75,30));
+                                                60,75,30));
         given(sessionCategoryMaps.getSessionCategory(BENEFIT_CODE,ISSUE_CODE,false,false))
                 .willReturn(new SessionCategoryMap(BenefitCode.PIP_NEW_CLAIM, Issue.DD,
-                        false,false,SessionCategory.CATEGORY_03,null));
+                                                   false, false, SessionCategory.CATEGORY_03, null));
 
         given(referenceDataServiceHolder.getHearingDurations()).willReturn(hearingDurations);
         given(referenceDataServiceHolder.getSessionCategoryMaps()).willReturn(sessionCategoryMaps);
@@ -114,6 +115,7 @@ class HearingsMappingTest extends HearingsMappingBase {
     @Test
     void updateIds() {
         List<CcdValue<OtherParty>> otherParties = new ArrayList<>();
+        JointParty jointParty = JointParty.builder().id("3").appointee(Appointee.builder().build()).build();
         otherParties.add(new CcdValue<>(OtherParty.builder()
                 .id("2")
                 .appointee(Appointee.builder().build())
@@ -126,7 +128,9 @@ class HearingsMappingTest extends HearingsMappingBase {
                         .rep(Representative.builder().build())
                         .build())
                 .otherParties(otherParties)
+                .jointParty(jointParty)
                 .build();
+
         HearingWrapper wrapper = HearingWrapper.builder()
                 .caseData(caseData)
                 .caseData(caseData)
@@ -143,6 +147,9 @@ class HearingsMappingTest extends HearingsMappingBase {
         assertNotNull(wrapper.getCaseData().getOtherParties().get(0).getValue().getRep().getId());
 
         assertNotNull(wrapper.getCaseData().getOtherParties().get(1).getValue().getId());
+
+        assertThat(wrapper.getCaseData().getJointParty().getAppointee().getId()).isNotNull();
+        assertThat(wrapper.getCaseData().getJointParty().getId()).isNotNull();
     }
 
     @DisplayName("getMaxId Test")

--- a/src/test/java/uk/gov/hmcts/reform/sscs/helper/mapping/HearingsPartiesMappingTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/helper/mapping/HearingsPartiesMappingTest.java
@@ -242,34 +242,55 @@ class HearingsPartiesMappingTest extends HearingsMappingBase {
     @EnumSource(value = YesNo.class)
     @NullSource
     void buildHearingPartiesDetailsJointParty(YesNo jointParty) throws InvalidMappingException {
-        // TODO SSCS-10378 - Finish Test
         String appellantId = "1";
+        String jointPartyId = "2";
+
+        Name name = Name.builder()
+            .title("title")
+            .firstName("first")
+            .lastName("last")
+            .build();
+
+        JointParty jointPartyDetails = JointParty.builder().id(jointPartyId)
+            .hasJointParty(jointParty)
+            .name(name)
+            .build();
+
         SscsCaseData caseData = SscsCaseData.builder()
-                .jointParty(JointParty.builder().hasJointParty(jointParty).build())
-                .appeal(Appeal.builder()
+            .jointParty(jointPartyDetails)
+            .appeal(Appeal.builder()
                         .hearingOptions(HearingOptions.builder().wantsToAttend("yes").build())
                         .hearingType("test")
                         .hearingSubtype(HearingSubtype.builder().wantsHearingTypeFaceToFace("yes").build())
                         .appellant(Appellant.builder()
-                                .id(appellantId)
-                                .name(Name.builder()
-                                        .title("title")
-                                        .firstName("first")
-                                        .lastName("last")
-                                        .build())
-                                .build())
+                                       .id(appellantId)
+                                       .name(name)
+                                       .build())
                         .build())
-                .build();
+            .build();
+
         HearingWrapper wrapper = HearingWrapper.builder()
-                .caseData(caseData)
-                .caseData(caseData)
-                .build();
+            .caseData(caseData)
+            .caseData(caseData)
+            .build();
 
         List<PartyDetails> partiesDetails = HearingsPartiesMapping.buildHearingPartiesDetails(wrapper, referenceDataServiceHolder);
 
         assertThat(partiesDetails.stream().filter(o -> appellantId.equalsIgnoreCase(o.getPartyID())).findFirst()).isPresent();
-
+        assertThat(partiesDetails.stream().anyMatch(o -> jointPartyId.equalsIgnoreCase(o.getPartyID())));
         assertThat(partiesDetails.stream().filter(o -> "DWP".equalsIgnoreCase(o.getPartyID())).findFirst()).isNotPresent();
+    }
+
+    @DisplayName("When HearingOption is  Null return empty string")
+    @Test
+    void getIndividualInterpreterLanguageWhenHearingOptionsNull() throws InvalidMappingException {
+
+        String individualInterpreterLanguage = HearingsPartiesMapping.getIndividualInterpreterLanguage(
+            null,
+            referenceDataServiceHolder
+        );
+
+        assertThat(individualInterpreterLanguage).isEmpty();
     }
 
     @DisplayName("buildHearingPartiesPartyDetails when Appointee is not null Parameterised Tests")
@@ -493,31 +514,6 @@ class HearingsPartiesMappingTest extends HearingsMappingBase {
         assertEquals(expected, result);
     }
 
-    @DisplayName("When hearingType not set then throw IllegalStateException")
-    @Test
-    void getIndividualPreferredHearingChannelNullHearingTypeTest() {
-        HearingOptions hearingOptions = HearingOptions.builder().build();
-
-        assertThatExceptionOfType(
-            IllegalStateException.class).isThrownBy(() ->
-            getIndividualPreferredHearingChannel(null,
-                HearingSubtype.builder().build(),
-                hearingOptions));
-    }
-
-    @DisplayName("When hearingSubType not set then throw IllegalStateException")
-    @Test
-    void getIndividualPreferredHearingChannelNullHearingSubtypeTest() {
-        HearingOptions hearingOptions = HearingOptions.builder().build();
-
-        assertThatExceptionOfType(
-            IllegalStateException.class).isThrownBy(() ->
-            getIndividualPreferredHearingChannel("TEST",
-                null,
-                hearingOptions));
-
-    }
-
     @DisplayName("When language passed in should return correct LOV format")
     @ParameterizedTest
     @CsvSource({"Acholi,ach", "Afrikaans,afr", "Akan,aka", "Albanian,alb", "Zaza,zza", "Zulu,zul"})
@@ -606,16 +602,12 @@ class HearingsPartiesMappingTest extends HearingsMappingBase {
         assertThat(result).isEqualTo(HearingChannel.NOT_ATTENDING.getHmcReference());
     }
 
-    @DisplayName("When hearingType and hearingSubType is null")
+    @DisplayName("When hearingType and hearingSubType are null then return null")
     @Test
     void whenHearingTypeAndHearingSubTypeIsNull() {
         HearingOptions hearingOptions = HearingOptions.builder().build();
 
-        assertThatExceptionOfType(
-            IllegalStateException.class).isThrownBy(() ->
-            getIndividualPreferredHearingChannel(null,
-                null,
-                hearingOptions));
+        assertThat(getIndividualPreferredHearingChannel(null, null, hearingOptions)).isNull();
     }
 
     @DisplayName("When hearing type oral and video then return LOV VIDEO")


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-10629


### Change description ###
- Merging Joint Party Changes into Demo QA branch (https://github.com/hmcts/sscs-hearings-api/pull/127)
- When buildHearingPartiesPartyDetails for "otherparty" do not use appeallant, pass null hearingType
- When hearingType or hearingSubtype is null, return null instead of throwing exception (null values are expected when otherParty or jointParty)
- Unit tests refactored + updated


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
