### PR TITLE
feat: change HMC api interface for cancel hearing operation

### DIFF
--- a/src/contractTest/java/uk/gov/hmcts/reform/sscs/consumer/HearingDeleteConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/sscs/consumer/HearingDeleteConsumerTest.java
@@ -128,7 +128,6 @@ class HearingDeleteConsumerTest extends BasePactTest {
             .uponReceiving("Request to DELETE hearing for not found hearing request")
             .path(ContractTestDataProvider.HEARING_PATH + "/" + NOT_FOUND_CASE_ID)
             .method(HttpMethod.DELETE.toString())
-            .query(ID + "=" + NOT_FOUND_CASE_ID)
             .body(ContractTestDataProvider.toJsonString(ContractTestDataProvider.generateHearingDeleteRequest()))
             .headers(ContractTestDataProvider.authorisedHeaders)
             .willRespondWith().status(HttpStatus.NOT_FOUND.value())

--- a/src/contractTest/java/uk/gov/hmcts/reform/sscs/consumer/HearingDeleteConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/sscs/consumer/HearingDeleteConsumerTest.java
@@ -54,9 +54,8 @@ class HearingDeleteConsumerTest extends BasePactTest {
     RequestResponsePact deleteHearingRequestForValidRequest(PactDslWithProvider builder) {
         return builder.given(CONSUMER_NAME + " successfully deleting a hearing request ")
             .uponReceiving("Request to delete hearing request")
-            .path(ContractTestDataProvider.HEARING_PATH)
+            .path(ContractTestDataProvider.HEARING_PATH + "/" + VALID_CASE_ID)
             .method(HttpMethod.DELETE.toString())
-            .query(ID + "=" + VALID_CASE_ID)
             .body(ContractTestDataProvider.toJsonString(ContractTestDataProvider.generateHearingDeleteRequest()))
             .headers(ContractTestDataProvider.authorisedHeaders)
             .willRespondWith()
@@ -70,9 +69,8 @@ class HearingDeleteConsumerTest extends BasePactTest {
         return builder.given(CONSUMER_NAME
                                  + " throws bad request error while trying to delete hearing")
             .uponReceiving("Request to DELETE hearing for bad hearing request")
-            .path(ContractTestDataProvider.HEARING_PATH)
+            .path(ContractTestDataProvider.HEARING_PATH + "/" + VALID_CASE_ID)
             .method(HttpMethod.DELETE.toString())
-            .query(ID + "=" + VALID_CASE_ID)
             .body(ContractTestDataProvider.toJsonString(ContractTestDataProvider.generateInvalidHearingDeleteRequest()))
             .headers(ContractTestDataProvider.authorisedHeaders)
             .willRespondWith().status(HttpStatus.BAD_REQUEST.value())
@@ -90,9 +88,8 @@ class HearingDeleteConsumerTest extends BasePactTest {
         return builder.given(CONSUMER_NAME
                                  + " throws unauthorised error while trying to delete hearing")
             .uponReceiving("Request to DELETE hearing for unauthorised hearing request")
-            .path(ContractTestDataProvider.HEARING_PATH)
+            .path(ContractTestDataProvider.HEARING_PATH + "/" + VALID_CASE_ID)
             .method(HttpMethod.DELETE.toString())
-            .query(ID + "=" + VALID_CASE_ID)
             .body(ContractTestDataProvider.toJsonString(ContractTestDataProvider.generateHearingDeleteRequest()))
             .headers(ContractTestDataProvider.unauthorisedHeaders)
             .willRespondWith().status(HttpStatus.UNAUTHORIZED.value())
@@ -110,8 +107,8 @@ class HearingDeleteConsumerTest extends BasePactTest {
         return builder.given(CONSUMER_NAME
                                  + " throws forbidden error while trying to delete hearing")
             .uponReceiving("Request to DELETE hearing for forbidden hearing request")
-            .path(ContractTestDataProvider.HEARING_PATH).method(HttpMethod.DELETE.toString())
-            .query(ID + "=" + FORBIDDEN_CASE_ID)
+            .path(ContractTestDataProvider.HEARING_PATH + "/" + FORBIDDEN_CASE_ID)
+            .method(HttpMethod.DELETE.toString())
             .body(ContractTestDataProvider.toJsonString(ContractTestDataProvider.generateHearingDeleteRequest()))
             .headers(ContractTestDataProvider.authorisedHeaders)
             .willRespondWith().status(HttpStatus.FORBIDDEN.value())
@@ -129,7 +126,8 @@ class HearingDeleteConsumerTest extends BasePactTest {
         return builder.given(CONSUMER_NAME
                                  + " throws not found request error while trying to delete hearing")
             .uponReceiving("Request to DELETE hearing for not found hearing request")
-            .path(ContractTestDataProvider.HEARING_PATH).method(HttpMethod.DELETE.toString())
+            .path(ContractTestDataProvider.HEARING_PATH + "/" + NOT_FOUND_CASE_ID)
+            .method(HttpMethod.DELETE.toString())
             .query(ID + "=" + NOT_FOUND_CASE_ID)
             .body(ContractTestDataProvider.toJsonString(ContractTestDataProvider.generateHearingDeleteRequest()))
             .headers(ContractTestDataProvider.authorisedHeaders)

--- a/src/contractTest/java/uk/gov/hmcts/reform/sscs/consumer/HearingDeleteConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/sscs/consumer/HearingDeleteConsumerTest.java
@@ -194,9 +194,8 @@ class HearingDeleteConsumerTest extends BasePactTest {
                              HearingCancelRequestPayload payload, HttpStatus status) {
         RestAssured.given().headers(headers)
             .contentType(ContentType.JSON)
-            .queryParam(ID, caseId)
             .body(ContractTestDataProvider.toJsonString(payload)).when()
-            .delete(mockServer.getUrl() + ContractTestDataProvider.HEARING_PATH)
+            .delete(mockServer.getUrl() + ContractTestDataProvider.HEARING_PATH + "/" + caseId)
             .then().statusCode(status.value())
             .and().extract()
             .body()

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/HearingsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/HearingsService.java
@@ -40,7 +40,8 @@ public class HearingsService {
         log.info("Processing Hearing Request for Case ID {}, Hearing State {} and Route {} and Cancellation Reason {}",
                 hearingRequest.getCcdCaseId(),
                 hearingRequest.getHearingState(),
-                hearingRequest.getHearingRoute());
+                hearingRequest.getHearingRoute(),
+                hearingRequest.getCancellationReason());
 
         processHearingWrapper(createWrapper(hearingRequest));
     }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/HmcHearingApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/HmcHearingApi.java
@@ -40,11 +40,11 @@ public interface HmcHearingApi {
         @RequestBody HearingRequestPayload hearingPayload
     );
 
-    @DeleteMapping(value = HEARING_ENDPOINT, consumes = MediaType.APPLICATION_JSON_VALUE)
+    @DeleteMapping(value = HEARING_ENDPOINT + "/{id}")
     HmcUpdateResponse cancelHearingRequest(
         @RequestHeader(AUTHORIZATION) String authorisation,
         @RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthorization,
-        @RequestParam(ID) String id,
+        @PathVariable String id,
         @RequestBody HearingCancelRequestPayload hearingDeletePayload
     );
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/HmcHearingApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/HmcHearingApi.java
@@ -40,7 +40,7 @@ public interface HmcHearingApi {
         @RequestBody HearingRequestPayload hearingPayload
     );
 
-    @DeleteMapping(value = HEARING_ENDPOINT + "/{id}")
+    @DeleteMapping(HEARING_ENDPOINT + "/{id}")
     HmcUpdateResponse cancelHearingRequest(
         @RequestHeader(AUTHORIZATION) String authorisation,
         @RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthorization,

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/HmcHearingApiService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/HmcHearingApiService.java
@@ -57,7 +57,7 @@ public class HmcHearingApiService {
     }
 
     public HmcUpdateResponse sendCancelHearingRequest(HearingCancelRequestPayload hearingPayload, String hearingId) {
-        log.debug("Sending Update Hearing Request for Hearing ID {} and request:\n{}",
+        log.debug("Sending Cancel Hearing Request for Hearing ID {} and request:\n{}",
                 hearingId,
                 hearingPayload);
         return hmcHearingApi.cancelHearingRequest(


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-10337


### Change description ###
Change API interface for hearings cancel - use path variables instead of request param as mandated by current HMC API


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
