### PR TITLE
feat/SSCS-10559: use overrideDuration field for Hearings

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/helper/mapping/HearingsDetailsMapping.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/helper/mapping/HearingsDetailsMapping.java
@@ -7,8 +7,10 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.ElementDisputedDetails;
 import uk.gov.hmcts.reform.sscs.ccd.domain.Entity;
 import uk.gov.hmcts.reform.sscs.ccd.domain.HearingOptions;
 import uk.gov.hmcts.reform.sscs.ccd.domain.OtherParty;
+import uk.gov.hmcts.reform.sscs.ccd.domain.OverrideSchedulingListingFields;
 import uk.gov.hmcts.reform.sscs.ccd.domain.PanelMember;
 import uk.gov.hmcts.reform.sscs.ccd.domain.Party;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SchedulingAndListingFields;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.model.HearingLocation;
 import uk.gov.hmcts.reform.sscs.model.HearingWrapper;
@@ -127,7 +129,14 @@ public final class HearingsDetailsMapping {
 
         Integer duration = getHearingDurationAdjournment(caseData);
         if (isNull(duration)) {
-            duration = getHearingDurationBenefitIssueCodes(caseData, referenceDataServiceHolder);
+            Integer overrideDuration = Optional.ofNullable(caseData.getSchedulingAndListingFields())
+                .map(SchedulingAndListingFields::getOverrideSchedulingListingFields)
+                .map(OverrideSchedulingListingFields::getOverrideDuration)
+                .orElse(0);
+
+            duration = overrideDuration > 0
+                ? overrideDuration
+                : getHearingDurationBenefitIssueCodes(caseData, referenceDataServiceHolder);
         }
 
         return nonNull(duration) ? duration : DURATION_DEFAULT;

--- a/src/test/java/uk/gov/hmcts/reform/sscs/helper/mapping/HearingsDetailsMappingTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/helper/mapping/HearingsDetailsMappingTest.java
@@ -24,9 +24,11 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.HearingType;
 import uk.gov.hmcts.reform.sscs.ccd.domain.Issue;
 import uk.gov.hmcts.reform.sscs.ccd.domain.Name;
 import uk.gov.hmcts.reform.sscs.ccd.domain.OtherParty;
+import uk.gov.hmcts.reform.sscs.ccd.domain.OverrideSchedulingListingFields;
 import uk.gov.hmcts.reform.sscs.ccd.domain.Party;
 import uk.gov.hmcts.reform.sscs.ccd.domain.Representative;
 import uk.gov.hmcts.reform.sscs.ccd.domain.Role;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SchedulingAndListingFields;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SessionCategory;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsIndustrialInjuriesData;
@@ -722,6 +724,29 @@ class HearingsDetailsMappingTest extends HearingsMappingBase {
         int result = HearingsDetailsMapping.getHearingDuration(caseData, referenceDataServiceHolder);
 
         assertEquals(expected, result);
+    }
+
+    @DisplayName("When an invalid adjournCaseDuration and adjournCaseDurationUnits is given and overrideDuration "
+        + "is present then override the duration of hearing")
+    @Test
+    void getHearingDurationWillReturnOverrideDurationWhenPresent() {
+        SscsCaseData caseData = SscsCaseData.builder()
+            .benefitCode(BENEFIT_CODE)
+            .issueCode(ISSUE_CODE)
+            .adjournCaseNextHearingListingDuration(null)
+            .adjournCaseNextHearingListingDurationUnits(null)
+            .appeal(Appeal.builder()
+                        .hearingOptions(HearingOptions.builder().build())
+                        .build())
+            .schedulingAndListingFields(SchedulingAndListingFields.builder()
+                                            .overrideSchedulingListingFields(OverrideSchedulingListingFields.builder()
+                                                                                 .overrideDuration(60)
+                                                                                 .build())
+                                            .build())
+            .build();
+        int result = HearingsDetailsMapping.getHearingDuration(caseData, referenceDataServiceHolder);
+
+        assertEquals(60, result);
     }
 
     @DisplayName("When the benefit or issue code is null getHearingDurationBenefitIssueCodes returns null Parameterized Tests")


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-10559


### Change description ###
- using new `overwriteDuration` field to override hearing duration value when applicable

Master copy of changes: https://github.com/hmcts/sscs-hearings-api/pull/206

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
