### PR TITLE
SSCS-10644-Linked-Cases-Update : fix only one case ref showing

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscs/controllers/ServiceHearingsControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscs/controllers/ServiceHearingsControllerTest.java
@@ -42,6 +42,7 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsIndustrialInjuriesData;
 import uk.gov.hmcts.reform.sscs.ccd.domain.YesNo;
 import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
+import uk.gov.hmcts.reform.sscs.exception.GetCaseException;
 import uk.gov.hmcts.reform.sscs.helper.mapping.HearingChannelMapping;
 import uk.gov.hmcts.reform.sscs.helper.mapping.HearingsPartiesMapping;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
@@ -53,6 +54,7 @@ import uk.gov.hmcts.reform.sscs.reference.data.model.HearingDuration;
 import uk.gov.hmcts.reform.sscs.reference.data.model.SessionCategoryMap;
 import uk.gov.hmcts.reform.sscs.reference.data.service.HearingDurationsService;
 import uk.gov.hmcts.reform.sscs.reference.data.service.SessionCategoryMapService;
+import uk.gov.hmcts.reform.sscs.service.CcdCaseService;
 import uk.gov.hmcts.reform.sscs.service.VenueService;
 import uk.gov.hmcts.reform.sscs.service.holder.ReferenceDataServiceHolder;
 
@@ -120,6 +122,7 @@ class ServiceHearingsControllerTest {
     @Mock
     private VenueService venueService;
 
+    private CcdCaseService ccdCaseService;
 
     static MockedStatic<HearingsPartiesMapping> hearingsPartiesMapping;
 
@@ -137,7 +140,7 @@ class ServiceHearingsControllerTest {
     }
 
     @BeforeEach
-    void setUp()  {
+    void setUp()  throws GetCaseException {
         List<CaseLink> linkedCases = new ArrayList<>();
         linkedCases.add(CaseLink.builder()
                 .value(CaseLinkDetails.builder()
@@ -204,6 +207,7 @@ class ServiceHearingsControllerTest {
         given(ccdService.getByCaseId(eq(CASE_ID), any(IdamTokens.class))).willReturn(caseDetails);
         given(authTokenGenerator.generate()).willReturn("s2s token");
         given(idamApiService.getIdamTokens()).willReturn(IdamTokens.builder().build());
+        given(ccdService.getByCaseId(eq(CASE_ID_LINKED), any(IdamTokens.class))).willReturn(caseDetails);
         hearingChannelMapping.when(() -> HearingChannelMapping.getHearingChannelsHmcReference(sscsCaseData))
             .thenReturn(List.of(FACE_TO_FACE.getHmcReference()));
 
@@ -311,4 +315,5 @@ class ServiceHearingsControllerTest {
         String dateTomorrow = LocalDate.now().plusDays(1).toString();
         return actualJson.replace("MOCK_DATE_TOMORROW", dateTomorrow);
     }
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/helper/mapping/HearingsCaseMapping.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/helper/mapping/HearingsCaseMapping.java
@@ -65,11 +65,7 @@ public final class HearingsCaseMapping {
     }
 
     public static String getPublicCaseName(SscsCaseData caseData) {
-        if (caseData.getCaseAccessManagementFields().getCaseNamePublic() == null || caseData.getCaseAccessManagementFields().getCaseNamePublic().isBlank()) {
-            return EMPTY_STRING;
-        } else {
-            return caseData.getCaseAccessManagementFields().getCaseNamePublic();
-        }
+        return caseData.getCaseAccessManagementFields().getCaseNamePublic();
     }
 
     public static boolean shouldBeAdditionalSecurityFlag(SscsCaseData caseData) {

--- a/src/main/java/uk/gov/hmcts/reform/sscs/helper/mapping/HearingsCaseMapping.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/helper/mapping/HearingsCaseMapping.java
@@ -25,6 +25,7 @@ import static uk.gov.hmcts.reform.sscs.model.hmc.reference.CaseCategoryType.CASE
 public final class HearingsCaseMapping {
 
     public static final String CASE_DETAILS_URL = "%s/cases/case-details/%s";
+    public static final String EMPTY_STRING = "";
 
     private HearingsCaseMapping() {
 
@@ -64,7 +65,11 @@ public final class HearingsCaseMapping {
     }
 
     public static String getPublicCaseName(SscsCaseData caseData) {
-        return caseData.getCaseAccessManagementFields().getCaseNamePublic();
+        if (caseData.getCaseAccessManagementFields().getCaseNamePublic() == null || caseData.getCaseAccessManagementFields().getCaseNamePublic().isBlank()) {
+            return EMPTY_STRING;
+        } else {
+            return caseData.getCaseAccessManagementFields().getCaseNamePublic();
+        }
     }
 
     public static boolean shouldBeAdditionalSecurityFlag(SscsCaseData caseData) {

--- a/src/main/java/uk/gov/hmcts/reform/sscs/helper/mapping/LinkedCasesMapping.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/helper/mapping/LinkedCasesMapping.java
@@ -4,8 +4,11 @@ import org.apache.commons.lang3.StringUtils;
 import uk.gov.hmcts.reform.sscs.ccd.domain.CaseLink;
 import uk.gov.hmcts.reform.sscs.ccd.domain.CaseLinkDetails;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.hmcts.reform.sscs.exception.GetCaseException;
 import uk.gov.hmcts.reform.sscs.model.service.linkedcases.ServiceLinkedCases;
+import uk.gov.hmcts.reform.sscs.service.CcdCaseService;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -20,17 +23,66 @@ public final class LinkedCasesMapping {
 
     public static List<ServiceLinkedCases> getLinkedCases(SscsCaseData caseData) {
         return Optional.ofNullable(caseData.getLinkedCase())
-                .orElseGet(Collections::emptyList).stream()
-                .filter(Objects::nonNull)
-                .map(CaseLink::getValue)
-                .filter(Objects::nonNull)
-                .map(CaseLinkDetails::getCaseReference)
-                .filter(StringUtils::isNotBlank)
-                .map(caseReference -> ServiceLinkedCases.builder()
-                    .caseReference(caseReference)
-                    .caseName(HearingsCaseMapping.getPublicCaseName(caseData))
-                    .reasonsForLink(HearingsCaseMapping.getReasonsForLink(caseData))
-                    .build())
-                .collect(Collectors.toList());
+            .orElseGet(Collections::emptyList).stream()
+            .filter(Objects::nonNull)
+            .map(CaseLink::getValue)
+            .filter(Objects::nonNull)
+            .map(CaseLinkDetails::getCaseReference)
+            .filter(StringUtils::isNotBlank)
+            .map(caseReference -> ServiceLinkedCases.builder()
+                .caseReference(caseReference)
+                .caseName(HearingsCaseMapping.getPublicCaseName(caseData))
+                .reasonsForLink(HearingsCaseMapping.getReasonsForLink(caseData))
+                .build())
+            .collect(Collectors.toList());
+    }
+    
+    @SuppressWarnings("PMD")
+    public static List<ServiceLinkedCases> getLinkedCasesWithNameAndReasons(SscsCaseData caseData, CcdCaseService ccdCaseService) throws GetCaseException {
+        List<String> linkedReferences = Optional.ofNullable(caseData.getLinkedCase())
+            .orElseGet(Collections::emptyList).stream()
+            .filter(Objects::nonNull)
+            .map(CaseLink::getValue)
+            .filter(Objects::nonNull)
+            .map(CaseLinkDetails::getCaseReference)
+            .collect(Collectors.toList());
+
+        if (linkedReferences.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<ServiceLinkedCases> serviceLinkedCases = new ArrayList<>();
+        ServiceLinkedCases linkedCase;
+        for (String linkRef : linkedReferences) {
+            if (linkRef != null) {
+                //suppressed warning
+                linkedCase = new ServiceLinkedCases();
+                linkedCase.setCaseReference(linkRef);
+                linkedCase.setCaseName(HearingsCaseMapping.getPublicCaseName(getLinkedCaseData(
+                    caseData,
+                    ccdCaseService,
+                    linkRef
+                )));
+                linkedCase.setReasonsForLink(HearingsCaseMapping.getReasonsForLink(caseData));
+                serviceLinkedCases.add(linkedCase);
+            }
+        }
+        return serviceLinkedCases;
+    }
+
+    private static SscsCaseData getLinkedCaseData(SscsCaseData caseData, CcdCaseService ccdCaseService, String caseReference) throws GetCaseException {
+        List<CaseLink> caseLink = caseData.getLinkedCase();
+
+        String linkedReference = null;
+
+        for (CaseLink link : caseLink) {
+            if (link != null && link.getValue() != null && link.getValue().getCaseReference() != null && link.getValue().getCaseReference().equals(caseReference)) {
+                linkedReference = link.getValue().getCaseReference();
+                return ccdCaseService.getCaseDetails(linkedReference).getData();
+            } else {
+                return new SscsCaseData();
+            }
+        }
+        return ccdCaseService.getCaseDetails(linkedReference).getData();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/helper/mapping/LinkedCasesMapping.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/helper/mapping/LinkedCasesMapping.java
@@ -36,8 +36,8 @@ public final class LinkedCasesMapping {
                 .build())
             .collect(Collectors.toList());
     }
-    
-    @SuppressWarnings("PMD")
+
+    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
     public static List<ServiceLinkedCases> getLinkedCasesWithNameAndReasons(SscsCaseData caseData, CcdCaseService ccdCaseService) throws GetCaseException {
         List<String> linkedReferences = Optional.ofNullable(caseData.getLinkedCase())
             .orElseGet(Collections::emptyList).stream()
@@ -52,11 +52,9 @@ public final class LinkedCasesMapping {
         }
 
         List<ServiceLinkedCases> serviceLinkedCases = new ArrayList<>();
-        ServiceLinkedCases linkedCase;
         for (String linkRef : linkedReferences) {
             if (linkRef != null) {
-                //suppressed warning
-                linkedCase = new ServiceLinkedCases();
+                ServiceLinkedCases linkedCase = new ServiceLinkedCases();
                 linkedCase.setCaseReference(linkRef);
                 linkedCase.setCaseName(HearingsCaseMapping.getPublicCaseName(getLinkedCaseData(
                     caseData,
@@ -76,7 +74,11 @@ public final class LinkedCasesMapping {
         String linkedReference = null;
 
         for (CaseLink link : caseLink) {
-            if (link != null && link.getValue() != null && link.getValue().getCaseReference() != null && link.getValue().getCaseReference().equals(caseReference)) {
+            String caseLinkReference = Optional.ofNullable(link.getValue())
+                .map(CaseLinkDetails::getCaseReference)
+                .orElse("");
+
+            if (caseLinkReference.equals(caseReference)) {
                 linkedReference = link.getValue().getCaseReference();
                 return ccdCaseService.getCaseDetails(linkedReference).getData();
             } else {

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/ServiceHearingsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/ServiceHearingsService.java
@@ -60,7 +60,7 @@ public class ServiceHearingsService {
 
         SscsCaseData caseData = ccdCaseService.getCaseDetails(request.getCaseId()).getData();
 
-        return LinkedCasesMapping.getLinkedCases(caseData);
+        return LinkedCasesMapping.getLinkedCasesWithNameAndReasons(caseData, ccdCaseService);
 
 
     }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/helper/mapping/LinkedCasesMappingTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/helper/mapping/LinkedCasesMappingTest.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.sscs.helper.mapping;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -22,6 +23,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class LinkedCasesMappingTest {
+    @InjectMocks
     private CcdCaseService ccdCaseService;
 
     @Mock

--- a/src/test/java/uk/gov/hmcts/reform/sscs/helper/mapping/LinkedCasesMappingTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/helper/mapping/LinkedCasesMappingTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.sscs.helper.mapping;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,7 +19,6 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.openMocks;
 
 @ExtendWith(MockitoExtension.class)
 class LinkedCasesMappingTest {
@@ -31,12 +29,6 @@ class LinkedCasesMappingTest {
 
     @Mock
     IdamService idamService;
-
-    @BeforeEach
-    void setUp() {
-        openMocks(this);
-        ccdCaseService = new CcdCaseService(ccdService, idamService);
-    }
 
     public static final String CASE_ID = "99250807409918";
     public static final String CASE_NAME = "Test Case Name";

--- a/src/test/java/uk/gov/hmcts/reform/sscs/helper/mapping/LinkedCasesMappingTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/helper/mapping/LinkedCasesMappingTest.java
@@ -15,7 +15,6 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.tuple;
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/uk/gov/hmcts/reform/sscs/helper/mapping/LinkedCasesMappingTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/helper/mapping/LinkedCasesMappingTest.java
@@ -1,28 +1,57 @@
 package uk.gov.hmcts.reform.sscs.helper.mapping;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.sscs.ccd.domain.*;
+import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
+import uk.gov.hmcts.reform.sscs.exception.GetCaseException;
+import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.model.service.linkedcases.ServiceLinkedCases;
+import uk.gov.hmcts.reform.sscs.service.CcdCaseService;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
 
+@ExtendWith(MockitoExtension.class)
 class LinkedCasesMappingTest {
+    private CcdCaseService ccdCaseService;
 
-    public static final long CASE_ID = 99250807409918L;
+    @Mock
+    private CcdService ccdService;
+
+    @Mock
+    IdamService idamService;
+
+    @BeforeEach
+    void setUp() {
+        openMocks(this);
+        ccdCaseService = new CcdCaseService(ccdService, idamService);
+    }
+
+    public static final String CASE_ID = "99250807409918";
     public static final String CASE_NAME = "Test Case Name";
 
     @DisplayName("When a case data is given with a linked case getLinkedCases returns any linked cases stored")
     @Test
-    void getLinkedCases() {
+    void getLinkedCases() throws GetCaseException {
         List<CaseLink> linkedCases = new ArrayList<>();
+
+        ccdCaseService = Mockito.mock(CcdCaseService.class);
+        when(ccdCaseService.getCaseDetails(CASE_ID)).thenReturn(buildSscsCaseData());
+
         linkedCases.add(CaseLink.builder()
                 .value(CaseLinkDetails.builder()
-                        .caseReference(String.valueOf(CASE_ID))
+                        .caseReference(CASE_ID)
                         .build())
                 .build());
         SscsCaseData caseData = SscsCaseData.builder()
@@ -30,17 +59,17 @@ class LinkedCasesMappingTest {
                 .caseAccessManagementFields(setCaseAccessManagementFields())
                 .build();
 
-        List<ServiceLinkedCases> result = LinkedCasesMapping.getLinkedCases(caseData);
+        List<ServiceLinkedCases> result = LinkedCasesMapping.getLinkedCasesWithNameAndReasons(caseData, ccdCaseService);
 
         assertThat(result)
             .isNotEmpty()
             .extracting("caseReference")
-            .containsOnly(String.valueOf(CASE_ID));
+            .containsOnly(CASE_ID);
 
         assertThat(result)
             .isNotEmpty()
             .extracting("caseName")
-            .containsOnly(String.valueOf(CASE_NAME));
+            .containsOnly(CASE_NAME);
 
         List<String> reasonsForLinkTest = new ArrayList<>();
         assertEquals(reasonsForLinkTest, result.get(0).getReasonsForLink());
@@ -48,11 +77,15 @@ class LinkedCasesMappingTest {
 
     @DisplayName("When a case data is given with a linkedCase with an null or a null value getLinkedCases returns any valid linked cases stored without error")
     @Test
-    void getLinkedCasesNullValue() {
+    void getLinkedCasesNullValue() throws GetCaseException {
         List<CaseLink> linkedCases = new ArrayList<>();
+
+        ccdCaseService = Mockito.mock(CcdCaseService.class);
+        when(ccdCaseService.getCaseDetails(CASE_ID)).thenReturn(buildSscsCaseData());
+
         linkedCases.add(CaseLink.builder()
                 .value(CaseLinkDetails.builder()
-                        .caseReference(String.valueOf(CASE_ID))
+                        .caseReference(CASE_ID)
                         .build())
                 .build());
         linkedCases.add(null);
@@ -62,17 +95,17 @@ class LinkedCasesMappingTest {
                 .caseAccessManagementFields(setCaseAccessManagementFields())
                 .build();
 
-        List<ServiceLinkedCases> result = LinkedCasesMapping.getLinkedCases(caseData);
+        List<ServiceLinkedCases> result = LinkedCasesMapping.getLinkedCasesWithNameAndReasons(caseData, ccdCaseService);
 
         assertThat(result)
             .isNotEmpty()
             .extracting("caseReference")
-            .containsOnly(String.valueOf(CASE_ID));
+            .containsOnly(CASE_ID);
 
         assertThat(result)
             .isNotEmpty()
             .extracting("caseName")
-            .containsOnly(String.valueOf(CASE_NAME));
+            .containsOnly(CASE_NAME);
 
         List<String> reasonsForLinkTest = new ArrayList<>();
         assertEquals(reasonsForLinkTest, result.get(0).getReasonsForLink());
@@ -80,11 +113,15 @@ class LinkedCasesMappingTest {
 
     @DisplayName("When a case data is given with a linkedCase that has a blank or null case reference getLinkedCases returns any valid linked cases stored without error")
     @Test
-    void getLinkedCasesBlankCaseReference() {
+    void getLinkedCasesBlankCaseReference() throws GetCaseException {
         List<CaseLink> linkedCases = new ArrayList<>();
+
+        ccdCaseService = Mockito.mock(CcdCaseService.class);
+        when(ccdCaseService.getCaseDetails(CASE_ID)).thenReturn(buildSscsCaseData());
+
         linkedCases.add(CaseLink.builder()
                 .value(CaseLinkDetails.builder()
-                        .caseReference(String.valueOf(CASE_ID))
+                        .caseReference(CASE_ID)
                         .build())
                 .build());
         linkedCases.add(CaseLink.builder()
@@ -100,17 +137,17 @@ class LinkedCasesMappingTest {
                 .caseAccessManagementFields(setCaseAccessManagementFields())
                 .build();
 
-        List<ServiceLinkedCases> result = LinkedCasesMapping.getLinkedCases(caseData);
+        List<ServiceLinkedCases> result = LinkedCasesMapping.getLinkedCasesWithNameAndReasons(caseData, ccdCaseService);
 
         assertThat(result)
             .isNotEmpty()
             .extracting("caseReference")
-            .containsOnly(String.valueOf(CASE_ID));
+            .containsOnly(CASE_ID, "");
 
         assertThat(result)
             .isNotEmpty()
             .extracting("caseName")
-            .containsOnly(String.valueOf(CASE_NAME));
+            .containsOnly(CASE_NAME, "");
 
         List<String> reasonsForLinkTest = new ArrayList<>();
         assertEquals(reasonsForLinkTest, result.get(0).getReasonsForLink());
@@ -118,12 +155,12 @@ class LinkedCasesMappingTest {
 
     @DisplayName("When a case data is given with a empty linkedCase object getLinkedCases returns an empty list")
     @Test
-    void getLinkedCasesEmptyLinkedCase() {
+    void getLinkedCasesEmptyLinkedCase() throws GetCaseException {
         SscsCaseData caseData = SscsCaseData.builder()
                 .linkedCase(new ArrayList<>())
                 .build();
 
-        List<ServiceLinkedCases> result = LinkedCasesMapping.getLinkedCases(caseData);
+        List<ServiceLinkedCases> result = LinkedCasesMapping.getLinkedCasesWithNameAndReasons(caseData, ccdCaseService);
 
         assertThat(result).isEmpty();
     }
@@ -144,5 +181,17 @@ class LinkedCasesMappingTest {
 
         return caseAccessManagementFields;
 
+    }
+
+    private SscsCaseDetails buildSscsCaseData() {
+        SscsCaseData caseData = new SscsCaseData();
+
+        CaseAccessManagementFields caseAccessManagementFields = new CaseAccessManagementFields();
+        caseAccessManagementFields.setCaseNames(CASE_NAME);
+        caseData.setCaseAccessManagementFields(caseAccessManagementFields);
+
+        return SscsCaseDetails.builder()
+            .data(caseData)
+            .build();
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/helper/mapping/LinkedCasesMappingTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/helper/mapping/LinkedCasesMappingTest.java
@@ -3,14 +3,10 @@ package uk.gov.hmcts.reform.sscs.helper.mapping;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.sscs.ccd.domain.*;
-import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
 import uk.gov.hmcts.reform.sscs.exception.GetCaseException;
-import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.model.service.linkedcases.ServiceLinkedCases;
 import uk.gov.hmcts.reform.sscs.service.CcdCaseService;
 
@@ -24,14 +20,9 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class LinkedCasesMappingTest {
-    @InjectMocks
+    @Mock
     private CcdCaseService ccdCaseService;
 
-    @Mock
-    private CcdService ccdService;
-
-    @Mock
-    IdamService idamService;
 
     public static final String CASE_ID = "99250807409918";
     public static final String CASE_NAME = "Test Case Name";
@@ -41,7 +32,6 @@ class LinkedCasesMappingTest {
     @Test
     void getSingleLinkedCases() throws GetCaseException {
 
-        ccdCaseService = Mockito.mock(CcdCaseService.class);
         when(ccdCaseService.getCaseDetails(CASE_ID)).thenReturn(buildSscsCaseData());
 
         List<CaseLink> linkedCases = new ArrayList<>();
@@ -62,15 +52,15 @@ class LinkedCasesMappingTest {
             .extracting("caseReference", "caseName")
             .containsOnly(tuple(CASE_ID, CASE_NAME));
 
-        List<String> reasonsForLinkTest = new ArrayList<>();
-        assertEquals(reasonsForLinkTest, result.get(0).getReasonsForLink());
+        assertThat(result)
+            .extracting("reasonsForLink")
+            .containsOnly(new ArrayList<>());
     }
 
     @DisplayName("When a case data is given with a linked case getLinkedCases returns any linked cases stored")
     @Test
     void getLinkedCases() throws GetCaseException {
 
-        ccdCaseService = Mockito.mock(CcdCaseService.class);
         when(ccdCaseService.getCaseDetails(CASE_ID)).thenReturn(buildSscsCaseData());
 
         when(ccdCaseService.getCaseDetails(SECOND_CASE_ID)).thenReturn(buildSscsCaseData());
@@ -95,16 +85,12 @@ class LinkedCasesMappingTest {
 
         assertThat(result)
             .isNotEmpty()
-            .extracting("caseReference")
-            .containsOnly(CASE_ID, SECOND_CASE_ID);
+            .extracting("caseReference", "caseName")
+            .containsOnly(tuple(CASE_ID, CASE_NAME), tuple(SECOND_CASE_ID, CASE_NAME));
 
         assertThat(result)
-            .isNotEmpty()
-            .extracting("caseName")
-            .containsOnly(CASE_NAME);
-
-        List<String> reasonsForLinkTest = new ArrayList<>();
-        assertEquals(reasonsForLinkTest, result.get(0).getReasonsForLink());
+            .extracting("reasonsForLink")
+            .containsOnly(new ArrayList<>());
     }
 
     @DisplayName("When a case data is given with a linkedCase with an null or a null value getLinkedCases returns any valid linked cases stored without error")
@@ -112,7 +98,6 @@ class LinkedCasesMappingTest {
     void getLinkedCasesNullValue() throws GetCaseException {
         List<CaseLink> linkedCases = new ArrayList<>();
 
-        ccdCaseService = Mockito.mock(CcdCaseService.class);
         when(ccdCaseService.getCaseDetails(CASE_ID)).thenReturn(buildSscsCaseData());
 
         linkedCases.add(CaseLink.builder()
@@ -133,9 +118,10 @@ class LinkedCasesMappingTest {
             .isNotEmpty()
             .extracting("caseReference", "caseName")
             .containsOnly(tuple(CASE_ID, CASE_NAME));
-        
-        List<String> reasonsForLinkTest = new ArrayList<>();
-        assertEquals(reasonsForLinkTest, result.get(0).getReasonsForLink());
+
+        assertThat(result)
+            .extracting("reasonsForLink")
+            .containsOnly(new ArrayList<>());
     }
 
     @DisplayName("When a case data is given with a linkedCase that has a blank or null case reference getLinkedCases returns any valid linked cases stored without error")
@@ -143,7 +129,6 @@ class LinkedCasesMappingTest {
     void getLinkedCasesBlankCaseReference() throws GetCaseException {
         List<CaseLink> linkedCases = new ArrayList<>();
 
-        ccdCaseService = Mockito.mock(CcdCaseService.class);
         when(ccdCaseService.getCaseDetails(CASE_ID)).thenReturn(buildSscsCaseData());
 
         linkedCases.add(CaseLink.builder()
@@ -166,22 +151,17 @@ class LinkedCasesMappingTest {
 
         List<ServiceLinkedCases> result = LinkedCasesMapping.getLinkedCasesWithNameAndReasons(caseData, ccdCaseService);
 
-        assertThat(result)
-            .isNotEmpty()
-            .extracting("caseReference")
-            .containsOnly(CASE_ID, "");
-
-        assertThat(result)
-            .isNotEmpty()
-            .extracting("caseName")
-            .containsOnly(CASE_NAME, null);
-
         List<String> reasonsForLinkTest = new ArrayList<>();
-        assertEquals(reasonsForLinkTest, result.get(0).getReasonsForLink());
+        assertThat(result)
+            .isNotEmpty()
+            .extracting("caseReference", "caseName")
+            .containsOnly(tuple(CASE_ID, CASE_NAME), tuple("", null));
+
+        assertThat(result)
+            .extracting("reasonsForLink")
+            .containsOnly(new ArrayList<>());
+
     }
-
-
-
 
     @DisplayName("When a case data is given with a empty linkedCase object getLinkedCases returns an empty list")
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-10644


### Change description ###
Update service Linked Hearings endpoint to return individual caseReferences


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
