### PR TITLE
suppresses CVE-2021-37533 and CVE-2016-3094

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -19,7 +19,7 @@
     <notes><![CDATA[
      these common libraries are being mistaken as Apache Commons Net
    ]]></notes>
-    <packageUrl regex="true">^pkg:maven\/org\-apache\-commons\/commons\-(?!net)\w+@.*$</packageUrl>
+    <packageUrl regex="true">^pkg:maven\/org(\-|\.)apache(\-|\.)commons\/commons\-(?!net)\w+@.*$</packageUrl>
     <cve>CVE-2021-37533</cve>
   </suppress>
   <suppress until = "2023-01-08">

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -24,7 +24,7 @@
   </suppress>
   <suppress until = "2023-01-08">
     <notes><![CDATA[
-   file name: qpid-jms-client-1.6.0.jar
+   incorrect tagging qpid-jms-client as qpid_java
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.qpid/qpid\-jms\-client@.*$</packageUrl>
     <cve>CVE-2016-3094</cve>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -8,4 +8,25 @@
     <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-.*?@[1-5]\..*$</packageUrl>
     <cve>CVE-2016-1000027</cve>
   </suppress>
+  <suppress until = "2023-01-01">
+    <notes><![CDATA[
+     these common libraries are being mistaken as Apache Commons Net
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven\/commons\-(?!net)\w+\/commons\-(?!net)\w+@.*$</packageUrl>
+    <cve>CVE-2021-37533</cve>
+  </suppress>
+  <suppress until = "2023-01-01">
+    <notes><![CDATA[
+     these common libraries are being mistaken as Apache Commons Net
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven\/org\-apache\-commons\/commons\-(?!net)\w+@.*$</packageUrl>
+    <cve>CVE-2021-37533</cve>
+  </suppress>
+  <suppress until = "2023-01-01">
+    <notes><![CDATA[
+   file name: qpid-jms-client-1.6.0.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.qpid/qpid\-jms\-client@.*$</packageUrl>
+    <cve>CVE-2016-3094</cve>
+  </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -8,21 +8,21 @@
     <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-.*?@[1-5]\..*$</packageUrl>
     <cve>CVE-2016-1000027</cve>
   </suppress>
-  <suppress until = "2023-01-01">
+  <suppress until = "2023-01-08">
     <notes><![CDATA[
      these common libraries are being mistaken as Apache Commons Net
    ]]></notes>
     <packageUrl regex="true">^pkg:maven\/commons\-(?!net)\w+\/commons\-(?!net)\w+@.*$</packageUrl>
     <cve>CVE-2021-37533</cve>
   </suppress>
-  <suppress until = "2023-01-01">
+  <suppress until = "2023-01-08">
     <notes><![CDATA[
      these common libraries are being mistaken as Apache Commons Net
    ]]></notes>
     <packageUrl regex="true">^pkg:maven\/org\-apache\-commons\/commons\-(?!net)\w+@.*$</packageUrl>
     <cve>CVE-2021-37533</cve>
   </suppress>
-  <suppress until = "2023-01-01">
+  <suppress until = "2023-01-08">
     <notes><![CDATA[
    file name: qpid-jms-client-1.6.0.jar
    ]]></notes>


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###
suppresses CVE-2021-37533 and CVE-2016-3094


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
