### PR TITLE
SSCS-12005 - Hearings changes to sort duration when standard timeslot adjournment

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/helper/mapping/OverridesMapping.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/helper/mapping/OverridesMapping.java
@@ -43,6 +43,13 @@ public final class OverridesMapping {
 
     }
 
+    public static OverrideFields getDefaultListingValues(@Valid SscsCaseData caseData) {
+        return Optional.ofNullable(caseData)
+            .map(SscsCaseData::getSchedulingAndListingFields)
+            .map(SchedulingAndListingFields::getDefaultListingValues)
+            .orElse(OverrideFields.builder().build());
+    }
+
     public static OverrideFields getOverrideFields(@Valid SscsCaseData caseData) {
         return Optional.ofNullable(caseData)
             .map(SscsCaseData::getSchedulingAndListingFields)

--- a/src/test/java/uk/gov/hmcts/reform/sscs/helper/mapping/HearingsDetailsMappingTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/helper/mapping/HearingsDetailsMappingTest.java
@@ -84,6 +84,12 @@ class HearingsDetailsMappingTest extends HearingsMappingBase {
 
     @BeforeEach
     void setUp() {
+        OverrideFields defaultListingValues = OverrideFields.builder()
+            .duration(60)
+            .build();
+        SchedulingAndListingFields slFields = SchedulingAndListingFields.builder()
+            .defaultListingValues(defaultListingValues)
+            .build();
         caseData = SscsCaseData.builder()
             .appeal(Appeal.builder()
                 .hearingOptions(HearingOptions.builder().wantsToAttend("yes").build())
@@ -91,6 +97,7 @@ class HearingsDetailsMappingTest extends HearingsMappingBase {
                     .wantsHearingTypeTelephone("yes")
                     .hearingTelephoneNumber(PHONE_NUMBER).build()).build())
             .processingVenue(PROCESSING_VENUE_1)
+            .schedulingAndListingFields(slFields)
             .build();
     }
 
@@ -104,6 +111,13 @@ class HearingsDetailsMappingTest extends HearingsMappingBase {
         given(refData.getHearingDurations()).willReturn(hearingDurations);
         given(refData.getSessionCategoryMaps()).willReturn(sessionCategoryMaps);
         given(refData.getVenueService()).willReturn(venueService);
+
+        OverrideFields defaultListingValues = OverrideFields.builder()
+            .duration(60)
+            .build();
+        SchedulingAndListingFields slFields = SchedulingAndListingFields.builder()
+            .defaultListingValues(defaultListingValues)
+            .build();
 
         // TODO Finish Test when method done
         caseData = SscsCaseData.builder()
@@ -122,6 +136,7 @@ class HearingsDetailsMappingTest extends HearingsMappingBase {
                 .region(REGION)
                 .build())
             .dwpIsOfficerAttending("Yes")
+            .schedulingAndListingFields(slFields)
             .build();
 
         HearingWrapper wrapper = HearingWrapper.builder()

--- a/src/test/java/uk/gov/hmcts/reform/sscs/helper/mapping/HearingsDurationMappingAdjournmentTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/helper/mapping/HearingsDurationMappingAdjournmentTest.java
@@ -6,14 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mock;
-import uk.gov.hmcts.reform.sscs.ccd.domain.AdjournCaseNextHearingDurationType;
-import uk.gov.hmcts.reform.sscs.ccd.domain.AdjournCaseNextHearingDurationUnits;
-import uk.gov.hmcts.reform.sscs.ccd.domain.Appeal;
-import uk.gov.hmcts.reform.sscs.ccd.domain.BenefitCode;
-import uk.gov.hmcts.reform.sscs.ccd.domain.HearingOptions;
-import uk.gov.hmcts.reform.sscs.ccd.domain.Issue;
-import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
-import uk.gov.hmcts.reform.sscs.ccd.domain.YesNo;
+import uk.gov.hmcts.reform.sscs.ccd.domain.*;
 import uk.gov.hmcts.reform.sscs.reference.data.model.HearingDuration;
 import uk.gov.hmcts.reform.sscs.service.holder.ReferenceDataServiceHolder;
 
@@ -39,6 +32,15 @@ class HearingsDurationMappingAdjournmentTest extends HearingsMappingBase {
     void setUp() {
         caseData.getAdjournment().setNextHearingListingDurationType(AdjournCaseNextHearingDurationType.NON_STANDARD);
         caseData.getAdjournment().setAdjournmentInProgress(YesNo.YES);
+
+        OverrideFields defaultListingValues = OverrideFields.builder()
+            .duration(45)
+            .build();
+        SchedulingAndListingFields slFields = SchedulingAndListingFields.builder()
+            .defaultListingValues(defaultListingValues)
+            .build();
+
+        caseData.setSchedulingAndListingFields(slFields);
     }
 
     @DisplayName("When a valid adjournCaseDuration and adjournCaseDurationUnits is given "
@@ -67,6 +69,13 @@ class HearingsDurationMappingAdjournmentTest extends HearingsMappingBase {
         + "uses default hearing duration")
     @Test
     void getHearingDurationAdjournmentReturnsNullWithFeatureFlagEnabled() {
+        OverrideFields defaultListingValues = OverrideFields.builder()
+            .duration(null)
+            .build();
+        SchedulingAndListingFields slFields = SchedulingAndListingFields.builder()
+            .defaultListingValues(defaultListingValues)
+            .build();
+
         caseData = SscsCaseData.builder()
             .benefitCode(BENEFIT_CODE)
             .issueCode(ISSUE_CODE)
@@ -75,6 +84,7 @@ class HearingsDurationMappingAdjournmentTest extends HearingsMappingBase {
                     .wantsToAttend("Yes")
                     .build())
                 .build())
+            .schedulingAndListingFields(slFields)
             .build();
 
         given(refData.getHearingDurations()).willReturn(hearingDurations);
@@ -100,6 +110,7 @@ class HearingsDurationMappingAdjournmentTest extends HearingsMappingBase {
 
         given(refData.getHearingDurations()).willReturn(hearingDurations);
         setAdjournmentDurationAndUnits(2, null);
+        caseData.getSchedulingAndListingFields().getDefaultListingValues().setDuration(null);
 
         int result = HearingsDurationMapping.getHearingDuration(caseData, refData);
 
@@ -120,6 +131,7 @@ class HearingsDurationMappingAdjournmentTest extends HearingsMappingBase {
         AdjournCaseNextHearingDurationUnits adjournCaseDurationUnits
     ) {
         setAdjournmentDurationAndUnits(adjournCaseDuration, adjournCaseDurationUnits);
+        caseData.getSchedulingAndListingFields().getDefaultListingValues().setDuration(null);
 
         assertThatThrownBy(() -> HearingsDurationMapping.getHearingDuration(caseData, refData))
             .isInstanceOf(NullPointerException.class);
@@ -147,11 +159,10 @@ class HearingsDurationMappingAdjournmentTest extends HearingsMappingBase {
     }
 
     @DisplayName("When getAdjournCaseNextHearingListingDurationType is standard "
-        + "getHearingDurationAdjournment returns null")
+        + "getHearingDurationAdjournment returns existing duration")
     @Test
-    void getHearingDurationAdjournment_nextHearingListingDurationTypeIsStandard() {
+    void getHearingDurationAdjournment_existingHearingListingDurationTypeIsStandard() {
         given(refData.getHearingDurations()).willReturn(hearingDurations);
-        given(hearingDurations.getHearingDurationBenefitIssueCodes(caseData)).willReturn(null);
 
         setAdjournmentDurationAndUnits(null, SESSIONS);
         caseData.getAdjournment().setNextHearingListingDurationType(AdjournCaseNextHearingDurationType.STANDARD);
@@ -165,7 +176,7 @@ class HearingsDurationMappingAdjournmentTest extends HearingsMappingBase {
 
         Integer result = HearingsDurationMapping.getHearingDurationAdjournment(caseData, refData.getHearingDurations());
 
-        assertThat(result).isNull();
+        assertThat(result).isEqualTo(45);
     }
 
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-12005

### Change description ###

An issue has been found during UAT whereby the standard time slot is not generating the duration expected by the business. This is because there are multiple ways that this should be calculated depending on the type of case. The system currently calculates this value based on the reference data for each case type however for some cases this value is set to Null as a Judge must define the duration so currently this would then set a default time of 60 mins which is incorrect. 

For cases where the value is NULL the business would like us to use the same duration that was set for the previous hearing as these would have been all been set by the Judge. 

However, rather than having 2 different methods the business would prefer a change to the functionality for all case types to ensure that when a case is adjourned and the user selects 'Standard time slot' we always set the hearing duration to the same time as the previous hearing. And we also need to ensure that If an interpreter is added via the adjournment journey we add 30 mins to the hearing duration if there is not already an interpreter on the case. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
