### PR TITLE
SSCS-12080 - Hearing duration is incorrectly set to 60 case is moved to F2F

### DIFF
--- a/src/test/java/uk/gov/hmcts/reform/sscs/helper/mapping/HearingsDurationMappingAdjournmentTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/helper/mapping/HearingsDurationMappingAdjournmentTest.java
@@ -179,4 +179,37 @@ class HearingsDurationMappingAdjournmentTest extends HearingsMappingBase {
         assertThat(result).isEqualTo(45);
     }
 
+    @DisplayName("When typeOfHearing is not equal to nextTypeOfHearing "
+        + "getHearingDurationAdjournment returns duration based on benefit code")
+    @Test
+    void getHearingDurationAdjournment_nextTypeOfHearing() {
+        given(refData.getHearingDurations()).willReturn(hearingDurations);
+
+        setAdjournmentDurationAndUnits(null, SESSIONS);
+
+        Adjournment adjournment = caseData.getAdjournment();
+
+        adjournment.setNextHearingListingDurationType(AdjournCaseNextHearingDurationType.STANDARD);
+        adjournment.setTypeOfHearing(AdjournCaseTypeOfHearing.PAPER);
+        adjournment.setTypeOfNextHearing(AdjournCaseTypeOfHearing.FACE_TO_FACE);
+
+        caseData.getSchedulingAndListingFields().getDefaultListingValues().setDuration(30);
+
+        HearingDuration duration = new HearingDuration();
+        duration.setBenefitCode(BenefitCode.PIP_NEW_CLAIM);
+        duration.setIssue(Issue.DD);
+        duration.setDurationInterpreter(45);
+        duration.setDurationPaper(30);
+        duration.setDurationFaceToFace(60);
+        List<HearingDuration> durationsList = new ArrayList<>();
+        durationsList.add(duration);
+        refData.getHearingDurations().setHearingDurations(durationsList);
+
+        given(hearingDurations.getHearingDurationBenefitIssueCodes(caseData)).willReturn(60);
+
+        Integer result = HearingsDurationMapping.getHearingDurationAdjournment(caseData, refData.getHearingDurations());
+
+        assertThat(result).isEqualTo(60);
+    }
+
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-12080

### Change description ###

During adjournment duration needs to be updated based on mapping json for benefit code to ensure we're correctly setting the duration if a hearing channel update is made as part of the journey. For example, moving from PAPER to F2F should update the duration on a new PIP CLAIM from 30 to 60.

Only changing hearings code here, not tribunals, and pared the change down to only updating if the type of hearing has been changed.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
