### PR TITLE
SSCSCI-694: bump up sscs-common version to include airLookup 18.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -339,7 +339,7 @@ dependencies {
   implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.2.10'
   implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.10'
 
-  implementation group: 'com.github.hmcts', name: 'sscs-common', version: '5.2.7'
+  implementation group: 'com.github.hmcts', name: 'sscs-common', version: '5.3.1'
 
   implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.36'
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
- https://tools.hmcts.net/jira/browse/SSCSCI-694

### Change description ###
- bump up sscs-common version to include airLookup 18.1

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
