### PR TITLE
Revert "Update dependency org.slf4j:slf4j-api to v2"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -342,7 +342,7 @@ dependencies {
 
   implementation group: 'com.github.hmcts', name: 'sscs-common', version: '5.3.1'
 
-  implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.12'
+  implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.36'
 
   implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.15.2'
   implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.15.2'


### PR DESCRIPTION
Reverts hmcts/sscs-hearings-api#515 to fix issue where logs are no longer generating