### PR TITLE
SSCS-12412 - FTA Hearings Error

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/helper/mapping/HearingsPartiesMapping.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/helper/mapping/HearingsPartiesMapping.java
@@ -222,15 +222,6 @@ public final class HearingsPartiesMapping {
         return getEntityRoleCode(entity).getHmcReference();
     }
 
-
-    public static IndividualDetails getDwpIndividualDetails(SscsCaseData caseData) {
-        return IndividualDetails.builder()
-            .firstName(DWP_PO_FIRST_NAME)
-            .lastName(DWP_PO_LAST_NAME)
-            .preferredHearingChannel(HearingChannelUtil.getHearingChannel(caseData))
-            .build();
-    }
-
     public static IndividualDetails getPartyIndividualDetails(Entity entity, HearingOptions hearingOptions,
                                                               HearingSubtype hearingSubtype,
                                                               String partyId,

--- a/src/main/java/uk/gov/hmcts/reform/sscs/helper/mapping/ServiceHearingPartiesMapping.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/helper/mapping/ServiceHearingPartiesMapping.java
@@ -23,7 +23,7 @@ import static java.util.Objects.nonNull;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.YesNo.isYes;
 import static uk.gov.hmcts.reform.sscs.helper.mapping.HearingsMapping.DWP_ID;
 import static uk.gov.hmcts.reform.sscs.model.hmc.reference.EntityRoleCode.RESPONDENT;
-import static uk.gov.hmcts.reform.sscs.model.hmc.reference.PartyType.INDIVIDUAL;
+import static uk.gov.hmcts.reform.sscs.model.hmc.reference.PartyType.ORGANISATION;
 
 @SuppressWarnings("PMD.ExcessiveImports")
 public final class ServiceHearingPartiesMapping {
@@ -101,7 +101,7 @@ public final class ServiceHearingPartiesMapping {
     public static PartyDetails createDwpPartyDetails(SscsCaseData caseData) {
         return PartyDetails.builder()
             .partyID(DWP_ID)
-            .partyType(INDIVIDUAL)
+            .partyType(ORGANISATION)
             .partyRole(RESPONDENT.getHmcReference())
             .organisationDetails(HearingsPartiesMapping.getDwpOrganisationDetails(caseData))
             .unavailabilityDow(HearingsPartiesMapping.getDwpUnavailabilityDayOfWeek())


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-12412

### Change description ###

Cases going into handling error:

Hearing Id:2000013741
Case ref:1685606957549516
Service code:BBA3
Error description:When amending the entity [DWP], you cannot change the EntityTypeCode or EntityClassCode. The existing entity is of type [IND] and class [PERSON]

Please advise on how we can get the listing request to LA




Possible scenario that needs to be investigated : It seems like the following is happening:

send a request with a party with partyID (e.g. 1234) type ORG
try to send an update of party with partyID 1234 and say this party is no longer an organisation, it's now a person.
HMC rejects

In reality, parties can't change between being organizations and real people. We can know about an organisation, and then in addition, maybe at a later time, know about people who work for that organisation. Both the organisation and the person are different, non-interchangeable things.

If this is the use case then what should happen is

send a request with a party with partyID (e.g.1234) of type ORG
If there is a person who works for that org that is known after the first request got sent, send an update with a new party, with a different partyID (e.g.4567) of type IND
HMC and LA should accept this new party, and both the organisation, and the person (who works for that org) are now visible in List Assist - as is expected.

1685606957549516

1691482388180467  

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
