### PR TITLE
SSCSCI-846 - Update spring to 2.7.18

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.12.RELEASE'
-  id 'org.springframework.boot' version '2.7.12'
+  id 'org.springframework.boot' version '2.7.18'
   id 'uk.gov.hmcts.java' version '0.12.27'
   id 'org.owasp.dependencycheck' version '9.0.6'
   id 'com.github.ben-manes.versions' version '0.42.0'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress until = "2024-05-01">
-    <cve>CVE-2023-5072</cve>
     <cve>CVE-2023-44487</cve>
     <cve>CVE-2023-42794</cve>
     <cve>CVE-2023-42795</cve>
@@ -9,8 +8,6 @@
     <cve>CVE-2023-41080</cve>
     <cve>CVE-2023-3635</cve>
     <cve>CVE-2023-35116</cve>
-    <cve>CVE-2023-24998</cve>
-    <cve>CVE-2023-46604</cve>
     <cve>CVE-2023-36052</cve>
     <cve>CVE-2023-33202</cve>
     <cve>CVE-2023-34055</cve>
@@ -19,3 +16,5 @@
     <cve>CVE-2023-34042</cve>
   </suppress>
 </suppressions>
+
+

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  <suppress until = "2024-05-01">
+  <suppress until = "2024-06-01">
     <cve>CVE-2023-44487</cve>
     <cve>CVE-2023-42794</cve>
     <cve>CVE-2023-42795</cve>
@@ -10,11 +10,9 @@
     <cve>CVE-2023-35116</cve>
     <cve>CVE-2023-36052</cve>
     <cve>CVE-2023-33202</cve>
-    <cve>CVE-2023-34055</cve>
     <cve>CVE-2023-46589</cve>
     <cve>CVE-2023-6378</cve>
     <cve>CVE-2023-34042</cve>
   </suppress>
 </suppressions>
-
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCSCI-846

### Change description ###
Upgrade spring-boot to 2.7.18 in sscs-hearings-api so that the critical vulnerability CVE-2023-46604 is fixed.

CVE-2023-46604 [Severity: Critical 9.8] via activemq-broker and activemq-client (5.16.6): The Java OpenWire protocol marshaller is vulnerable to Remote Code Execution. This vulnerability may allow a remote attacker with network access to either a Java-based OpenWire broker or client to run arbitrary shell commands by manipulating serialized class types in the OpenWire protocol to cause either the client or the broker (respectively) to instantiate any class on the classpath. Users are recommended to upgrade both brokers and clients to version 5.15.16, 5.16.7, 5.17.6, or 5.18.3 which fixes this issue.

Activemq-broker and activemq-client (5.16.6) are transitive dependencies via spring-boot. Upgrade spring-boot from 2.7.12 to 2.7.18 (patch), this will also upgrade activemq-broker and activemq-client to recommended version (5.16.7).



